### PR TITLE
Do not provide the feature test-helper in the templates either

### DIFF
--- a/templates/test/test-helper.el
+++ b/templates/test/test-helper.el
@@ -34,8 +34,7 @@
 (require 'ert)
 (require 'el-mock)
 (eval-when-compile
-    (require 'cl))
+  (require 'cl))
 (require '${package-name})
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
As per https://github.com/rejeep/ert-runner.el/issues/38#issuecomment-293126890, this also removes `(provide 'test-helper)` from the file in the templates directory.

The second commit adds the file `.nosearch` to help tools that extract features and to prevent `load-path` pollution.